### PR TITLE
enable user-local default mappings

### DIFF
--- a/doc/gf-user.txt
+++ b/doc/gf-user.txt
@@ -70,6 +70,26 @@ https://github.com/kana/vim-gf-user
 INTERFACE					*gf-user-interface*
 
 ------------------------------------------------------------------------------
+COMMANDS					*gf-user-commands*
+
+:GfUserDefaultKeyMappings[!] [args]            *:GfUserDefaultKeyMappings*
+
+    Define the default key mappings.  If [!] is given, redefine the
+    default key mappings.  This command doesn't override existing {lhs}s
+    unless [!] is given.
+    Accepts optional arguments [args] such as <buffer> or <nowait> that are
+    passed to nmap and xmap mapping <Plug>(gf-user-gf), <Plug>(gf-user-gF),
+    <Plug>(gf-user-<C-w>f), ... to the corresponding gf, gF, CTRL-W_f, ...
+    mappings.
+
+    For example, the default mappings can be added buffer-locally to all
+    buffers of filetype diff by adding the following to your |vimrc|:
+>
+    let g:gf_user_no_default_key_mappings = 1
+    autocmd FileType diff GfUserDefaultKeyMappings! <buffer>
+<
+
+------------------------------------------------------------------------------
 FUNCTIONS					*gf-user-functions*
 
 gf#user#extend({funcname}, {priority})		*gf#user#extend()*

--- a/plugin/gf/user.vim
+++ b/plugin/gf/user.vim
@@ -50,10 +50,11 @@ call s:define_ui_key_mappings()
 
 
 
-command! -bang -bar -nargs=0 GfUserDefaultKeyMappings
-\ call s:cmd_GfUserDefaultKeyMappings(<bang>0)
-function! s:cmd_GfUserDefaultKeyMappings(banged_p)
-  let modifier = a:banged_p ? '' : '<unique>'
+command! -bang -nargs=* GfUserDefaultKeyMappings
+\ call s:cmd_GfUserDefaultKeyMappings(<bang>0, <q-args>)
+function! s:cmd_GfUserDefaultKeyMappings(banged_p, args)
+  let modifier  = a:banged_p ? '' : '<unique>'
+  let modifier .= substitute(a:args, '\S\+', '<\0>', 'g')
   for gf_cmd in ['gf', 'gF',
   \              '<C-w>f', '<C-w><C-f>', '<C-w>F',
   \              '<C-w>gf', '<C-w>gF']

--- a/plugin/gf/user.vim
+++ b/plugin/gf/user.vim
@@ -50,11 +50,11 @@ call s:define_ui_key_mappings()
 
 
 
-command! -bang -nargs=* GfUserDefaultKeyMappings
+command! -bang -bar -nargs=* GfUserDefaultKeyMappings
 \ call s:cmd_GfUserDefaultKeyMappings(<bang>0, <q-args>)
 function! s:cmd_GfUserDefaultKeyMappings(banged_p, args)
   let modifier  = a:banged_p ? '' : '<unique>'
-  let modifier .= substitute(a:args, '\S\+', '<\0>', 'g')
+  let modifier .= a:args
   for gf_cmd in ['gf', 'gF',
   \              '<C-w>f', '<C-w><C-f>', '<C-w>F',
   \              '<C-w>gf', '<C-w>gF']


### PR DESCRIPTION
The gf-user plug-in has as one main implementation the gf-diff plug-in which is very useful in diffs, but maybe less in other file types. With this modification, the default mappings can be added buffer-locally, for example by

```vim
let g:gf_user_no_default_key_mappings = 1
autocmd FileType git,gitcommit,diff GfUserDefaultKeyMappings! buffer
```

Another possible use case would be adding `nowait`, if there are other mappings extending `gf`.